### PR TITLE
Configure devcontainer services to auto-start on container launch

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       # Persist bash history
       - devcontainer-bashhistory:/commandhistory
 
-    # Overrides default command so things don't shut down after the process ends
-    command: sleep infinity
+    # Start the Flask backend automatically
+    command: /bin/bash -c "cd /workspace && python3 backend/python/app.py"
 
     # Environment variables
     environment:
@@ -57,8 +57,8 @@ services:
       # Cache node_modules for performance
       - frontend-node-modules:/workspace/frontend/node_modules
 
-    # Overrides default command so things don't shut down after the process ends
-    command: sleep infinity
+    # Start the Express frontend automatically
+    command: /bin/bash -c "cd /workspace/frontend && npm start"
 
     # Environment variables
     environment:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,23 +58,18 @@ SQLite database (`database/schema.sql`) with five main tables:
 
 #### Using Development Container (Recommended)
 
-The project includes a Docker Compose-based multi-service development environment:
+The project includes a Docker Compose-based multi-service development environment with **auto-starting services**:
 
 1. Open project in VS Code
 2. Press `F1` → "Dev Containers: Reopen in Container"
 3. Wait for all containers to build and dependencies to install
-4. Run the services:
-   ```bash
-   # Start backend (from app container terminal)
-   python3 backend/python/app.py
-
-   # Start frontend (in a separate terminal)
-   cd frontend && npm start
-   ```
+4. **Services auto-start automatically!** Access immediately:
+   - Frontend UI: http://localhost:3000
+   - Backend API: http://localhost:5000
 
 **Multi-Service Architecture:**
-- **Backend Container**: Python 3.11 with Flask API (ports 5000, 5001)
-- **Frontend Container**: Node.js 18 with Express UI (port 3000)
+- **Backend Container**: Python 3.11 with Flask API (ports 5000, 5001) - **auto-starts on container launch**
+- **Frontend Container**: Node.js 18 with Express UI (port 3000) - **auto-starts on container launch**
 - **App Container**: Main development workspace with both Python and Node.js tools
 - All services connected via Docker network for inter-service communication
 - Health checks ensure services start in correct order
@@ -82,7 +77,9 @@ The project includes a Docker Compose-based multi-service development environmen
 **Features:**
 - Python 3.11 and Node.js 18 pre-installed
 - All dependencies auto-installed (Python + Node.js)
-- Ports 3000, 5000, and 5001 auto-forwarded
+- **Backend and frontend auto-start on container open** - no manual startup needed
+- Services immediately accessible from local browser
+- Ports 3000, 5000, and 5001 auto-forwarded to host machine
 - Persistent bash history
 - Node modules cached for performance
 - VS Code extensions (Pylance, Black, Flake8)
@@ -91,6 +88,13 @@ The project includes a Docker Compose-based multi-service development environmen
 - Backend: `PYTHONPATH=/workspace`, `API_PORT=5000`
 - Frontend: `API_URL=http://backend:5000`, `PORT=3000`
 - Frontend connects to backend via Docker network using service name `backend`
+
+**Viewing Service Logs:**
+```bash
+# From host machine or within any container terminal
+docker logs -f openid-federation-manager-backend-1
+docker logs -f openid-federation-manager-frontend-1
+```
 
 See `.devcontainer/README.md` for detailed multi-service setup documentation.
 
@@ -503,30 +507,34 @@ The project includes a complete Docker Compose-based multi-service development e
 - `.devcontainer/README.md` - Detailed multi-service documentation
 
 **What's Included:**
-- **Backend Container**: Python 3.11 with Flask and all dependencies
-- **Frontend Container**: Node.js 18 with Express and all dependencies
+- **Backend Container**: Python 3.11 with Flask and all dependencies - **auto-starts on launch**
+- **Frontend Container**: Node.js 18 with Express and all dependencies - **auto-starts on launch**
 - **App Container**: Combined workspace with both Python and Node.js tools
 - Git, SQLite3, and build tools
 - VS Code extensions for Python and JavaScript development
 - Pre-configured environment variables for all services
-- Automatic port forwarding (3000, 5000, 5001)
+- Automatic port forwarding (3000, 5000, 5001) to host machine
 - Persistent bash history
 - Docker networking for inter-service communication
 - Health checks for all services
 
 **Architecture Benefits:**
 - Services run in isolation but can communicate
+- **Services auto-start when container opens** - immediate browser access
 - Frontend automatically connects to backend via Docker network
 - Each service has optimized dependencies
 - Node modules cached for better performance
-- Services can be started/stopped independently
+- Services accessible from local browser via localhost
+- No manual service startup required
 
 **When to Use:**
 - Recommended for all new developers
 - Ensures consistent full-stack environment across platforms
 - No local Python/Node.js/dependency management needed
+- **Fastest onboarding** - services auto-start, immediately accessible from browser
 - Faster onboarding for full-stack development
 - Testing inter-service communication
+- Preferred for development with instant browser access
 
 **When Not to Use:**
 - If Docker Desktop is not available

--- a/README.md
+++ b/README.md
@@ -114,19 +114,28 @@ The server will start on `http://0.0.0.0:5000` (or your configured host/port).
 
 ### Running in Development Container
 
-If you're using the development container, the backend and frontend services are pre-configured. Simply open the integrated terminal in VS Code and run:
+If you're using the development container, the backend and frontend services **auto-start automatically** when the container opens. You can immediately access:
 
-**Backend:**
+- **Frontend UI**: http://localhost:3000
+- **Backend API**: http://localhost:5000
+
+All dependencies are pre-installed, services start automatically, and ports 3000, 5000, and 5001 are automatically forwarded to your host machine.
+
+**To view service logs:**
 ```bash
-python3 backend/python/app.py
+docker logs -f openid-federation-manager-backend-1
+docker logs -f openid-federation-manager-frontend-1
 ```
 
-**Frontend (in a separate terminal):**
+**To manually restart services (if needed):**
 ```bash
-cd frontend && npm start
-```
+# Restart all services
+docker-compose -f .devcontainer/docker-compose.yml restart
 
-All dependencies are pre-installed, and ports 3000, 5000, and 5001 are automatically forwarded to your host machine.
+# Restart specific service
+docker-compose -f .devcontainer/docker-compose.yml restart backend
+docker-compose -f .devcontainer/docker-compose.yml restart frontend
+```
 
 ## Running the Frontend
 
@@ -143,30 +152,26 @@ The OpenID Federation Manager includes a web-based user interface built with Nod
 
 **Prerequisites:**
 - Development container already set up (see "Option 1: Development Container" above)
-- Backend service running on port 5000
 
 **Steps:**
 
-1. Open a terminal in VS Code (inside the dev container)
-
-2. Start the backend service (if not already running):
-   ```bash
-   python3 backend/python/app.py
-   ```
-
-3. In a **separate terminal**, start the frontend:
-   ```bash
-   cd frontend
-   npm start
-   ```
-
-4. Access the web UI at http://localhost:3000
+1. Open the project in VS Code with Dev Containers extension
+2. Press `F1` → "Dev Containers: Reopen in Container"
+3. Wait for the container to build
+4. **Both backend and frontend auto-start automatically!**
+5. Access the web UI at http://localhost:3000
 
 **Environment Variables (Dev Container):**
 These are pre-configured in `.devcontainer/docker-compose.yml`:
 - `PORT=3000` - Frontend server port
 - `API_URL=http://backend:5000` - Backend API endpoint (uses Docker network)
 - `NODE_ENV=development` - Development mode
+
+**Services are immediately accessible:**
+- Frontend UI: http://localhost:3000
+- Backend API: http://localhost:5000
+
+No manual service startup required!
 
 ### Option 2: Running Frontend Locally
 
@@ -218,7 +223,6 @@ PORT=3001 API_URL=http://localhost:5001 npm start
 
 **Prerequisites:**
 - Docker and Docker Compose installed
-- Backend service container running
 
 **Steps:**
 
@@ -226,6 +230,10 @@ PORT=3001 API_URL=http://localhost:5001 npm start
    ```bash
    docker-compose -f .devcontainer/docker-compose.yml up
    ```
+
+   Services will auto-start and be immediately accessible:
+   - Frontend UI: http://localhost:3000
+   - Backend API: http://localhost:5000
 
    Or start services individually:
    ```bash
@@ -236,15 +244,15 @@ PORT=3001 API_URL=http://localhost:5001 npm start
    docker-compose -f .devcontainer/docker-compose.yml up frontend
    ```
 
-2. Access the web UI at http://localhost:3000
-
 **Docker Compose Features:**
 - **Multi-service architecture** - Backend, frontend, and app containers
+- **Auto-start on container launch** - Services start automatically, no manual startup needed
 - **Automatic dependency management** - Frontend waits for backend health check
 - **Inter-service networking** - Containers communicate via `federation-network`
 - **Health checks** - Ensures services start in correct order
 - **Volume mounting** - Source code mounted for live development
 - **Node modules caching** - Faster rebuilds and better performance
+- **Immediate browser access** - Services accessible at localhost via port forwarding
 
 **View logs:**
 ```bash


### PR DESCRIPTION
## Summary

Modified the devcontainer docker-compose.yml to automatically start backend and frontend services when the container opens, enabling immediate browser access without manual service startup.

## Changes

- **Backend service**: Changed command from `sleep infinity` to automatically run Flask app
- **Frontend service**: Changed command from `sleep infinity` to automatically run Express app
- Services now start automatically and are accessible at:
  - Frontend UI: http://localhost:3000
  - Backend API: http://localhost:5000

## Benefits

- Improved developer experience - no need to manually start services
- Immediate access to web UI after container opens
- Consistent startup behavior across all developers
- Services remain accessible from local browser via port forwarding

## Testing

- [ ] Rebuild devcontainer and verify backend starts automatically
- [ ] Verify frontend starts automatically and connects to backend
- [ ] Confirm http://localhost:3000 is accessible from local browser
- [ ] Confirm http://localhost:5000 is accessible from local browser
- [ ] Check service logs for any startup errors

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)