### PR TITLE
Add critical warning to always use feature branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,49 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## ⚠️ CRITICAL: Always Use Feature Branches
+
+**NEVER commit directly to the `main` branch unless explicitly instructed.**
+
+For ALL development work, you MUST:
+
+1. **Create a feature branch** with appropriate naming:
+   - `feature/<description>` for new features
+   - `fix/<description>` for bug fixes
+   - `docs/<description>` for documentation
+   - `refactor/<description>` for refactoring
+
+2. **Commit all changes to the feature branch**
+
+3. **Push the feature branch to remote**
+
+4. **Create a pull request** for review before merging to main
+
+**Example workflow:**
+```bash
+# Create feature branch
+git checkout -b feature/test-suite-implementation
+
+# Make changes and commit
+git add .
+git commit -m "Add comprehensive test suite"
+
+# Push feature branch
+git push origin feature/test-suite-implementation
+
+# Create PR (use gh cli or GitHub UI)
+gh pr create --title "Add comprehensive test suite" --body "Details..."
+```
+
+**Only commit directly to main for:**
+- Emergency hotfixes (with immediate follow-up PR)
+- Critical security patches
+- Minor typo fixes in documentation
+
+See "Development Workflow" section below for complete details.
+
+---
+
 ## Project Overview
 
 OpenID Federation Manager is a Python/Flask application implementing OpenID Federation (draft 44) as an intermediate entity/federation operator. It manages registration and entity statements for OpenID Providers (OP) and Relying Parties (RP) in a federation.


### PR DESCRIPTION
## Summary

Adds a prominent warning section at the top of CLAUDE.md to prevent accidental direct commits to the main branch.

## Changes

- Added **"CRITICAL: Always Use Feature Branches"** section at the beginning of CLAUDE.md
- Includes step-by-step workflow requirements for feature branch development
- Provides concrete example commands for the proper workflow
- Lists only exceptions where direct main commits are allowed (emergencies, security patches, minor typo fixes)
- References the detailed "Development Workflow" section later in the document

## Motivation

This change ensures Claude Code always follows proper git workflow by:
1. Creating feature branches for all development work
2. Committing changes to feature branches
3. Pushing feature branches to remote
4. Creating pull requests for review before merging to main

This prevents accidental direct commits to main and enforces the PR workflow established in the Development Workflow section.

## Test Plan

- [x] Verified CLAUDE.md renders correctly with new section
- [x] Confirmed section appears prominently at document start
- [x] Verified example commands are correct and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)